### PR TITLE
fix: typo in 2-minutes-to-stow

### DIFF
--- a/pages/til/2-minutes-to-stow.md
+++ b/pages/til/2-minutes-to-stow.md
@@ -58,7 +58,7 @@ deeper level.
 mkdir ~/dotfiles/nvim/.config/nvim/ -p
 cd ~/dotfiles
 mv ~/.config/nvim/ ~/dotfiles/nvim/.config/nvim/
-stow zsh
+stow nvim
 ```
 
 > !notice how the nvim directory inside of dotfiles is structured like it would


### PR DESCRIPTION
I think this should be "nvim", not "zsh".